### PR TITLE
fix: resolve setuptools build-backend error on pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "klustershield"


### PR DESCRIPTION
## Summary

`pip install -e .` fails with:

```
BackendUnavailable: Cannot import 'setuptools.backends.legacy'
```

The `build-backend` in `pyproject.toml` was set to an invalid/internal module path. This PR changes it to the standard `setuptools.build_meta`, which is the correct and documented build backend for setuptools-based projects.

## Changes

- **pyproject.toml**: Changed `build-backend` from `"setuptools.backends.legacy:build"` to `"setuptools.build_meta"`

## Testing

After this fix, `pip install -e .` completes successfully without the `BackendUnavailable` error.

Closes #1
